### PR TITLE
CI: drop focal reprobuild and add resolute instead

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false    # Let each build finish.
       matrix:
-        version: ['focal', 'jammy', 'noble']
+        version: ['jammy', 'noble', 'resolute']
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/contrib/reprobuild/Dockerfile.resolute
+++ b/contrib/reprobuild/Dockerfile.resolute
@@ -1,4 +1,4 @@
-FROM focal
+FROM ubuntu:resolute
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -18,41 +18,29 @@ RUN apt-get update \
     file \
     gettext \
     git \
+    curl \
+    libsqlite3-dev \
     libpq-dev \
     libsodium23 \
     libsodium-dev \
+    lowdown \
     libtool \
     m4 \
     sudo \
     unzip \
     wget \
-    zip \
-    && cd /tmp \
-    && wget https://github.com/kristapsdz/lowdown/archive/refs/tags/VERSION_1_0_2.tar.gz \
-    && tar -xzf VERSION_1_0_2.tar.gz \
-    && cd lowdown-VERSION_1_0_2 \
-    && ./configure \
-    && make \
-    && make install \
-    && ldconfig \
-    && cd / \
-    && rm -rf /tmp/VERSION_1_0_2.tar.gz /tmp/lowdown-VERSION_1_0_2
+    jq \
+    zip
 
-# Ensure correct ownership
-RUN chown root:root /etc/sudoers
-RUN chown root:root /usr/lib/sudo/sudoers.so
+# Configure /repo/.git as 'safe.directory'
+RUN git config --global --add safe.directory /repo/.git
 
-# Download and install jq from official repository
-RUN wget -O /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 \
-    && chmod +x /usr/local/bin/jq
-
-# install Python3.10 (more reproducible than relying on python3-setuptools)
+# Install Python3.10 (more reproducible than relying on python3-setuptools)
 RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv && \
     apt-get install -y --no-install-recommends \
     libbz2-dev \
     libffi-dev \
     libreadline-dev \
-    libsqlite3-dev \
     libssl-dev \
     zlib1g-dev && \
     pyenv install 3.10.0 && \


### PR DESCRIPTION
Changelog-None

> [!IMPORTANT]
>
> 26.06 FREEZE April 30th: Non-bugfix PRs not ready by this date will wait for 26.09.
>
> RC1 is scheduled on _May 14th_
>
> The final release is scheduled for June 1st.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
